### PR TITLE
Fixing gemspec for chore newrelic

### DIFF
--- a/chore-new_relic.gemspec
+++ b/chore-new_relic.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = Chore::NewRelic::VERSION
   spec.authors       = ["Tapjoy"]
   spec.email         = ["eng-group-arch@tapjoy.com"]
-  spec.summary       = "Tapjoy specific NewRelic integration for chore"
-  spec.description   = "A repository for Tapjoy specific NewRelic integrations"
+  spec.summary       = "NewRelic integration for chore"
+  spec.description   = "A repository for NewRelic integrations"
   spec.homepage      = ""
   spec.license       = "MIT"
 


### PR DESCRIPTION
ping @tannerburson @obrie @ydderd 

Same problem as the plugins gem, does not build as written. Keeping the requirements as they exist in Chore
