### PR TITLE
make compatible with the riak newrelic rpm

### DIFF
--- a/lib/chore/new_relic.rb
+++ b/lib/chore/new_relic.rb
@@ -1,4 +1,4 @@
-gem 'newrelic_rpm', '>= 3.7.0'
+gem 'newrelic_rpm', '>= 3.6.0'
 require 'new_relic/agent/instrumentation/controller_instrumentation'
 
 require 'chore'


### PR DESCRIPTION
@tannerburson @StabbyCutyou 

current `chore-new_relic` is not compatible with any projects using the riak monitoring in the `Tapjoy` fork of the `newrelic_rpm` gem.

Why does this matter?

In Yosemite, zookeeper does not seem to install cleanly. To avoid the zookeeper issue (and still run all the services locally that have hard dependencies on one another, namely device_identity_service, virtual_currency_service, and tapjoyserver) I had to upgrade chore on DiS and VCS, since they were never upgraded when we split out the `chore-core` business.

So I did it myself, and I just want to make sure no one's going to flip out if we loosen the dependency a bit. Is there truly a hard requirement for `newrelic_rpm` 3.7.x?
