### PR TITLE
Fix an issue in NewRelic RPM v3.8.1.221.

### DIFF
--- a/lib/chore/new_relic.rb
+++ b/lib/chore/new_relic.rb
@@ -1,4 +1,5 @@
 gem 'newrelic_rpm', '>= 3.7.0'
+require 'new_relic/agent/instrumentation'
 require 'new_relic/agent/instrumentation/controller_instrumentation'
 
 require 'chore'


### PR DESCRIPTION
 Dependency tree changes, and you can long longer just load controller_instrumentation alone.

Other NewRelic plugins have the same issue, see:
https://github.com/mitchellhenke/newrelic-roda/commit/ffca7cb0b96c2efe2b4f1e62b73d79e0d5b00498
https://github.com/xinminlabs/newrelic-grape/commit/ffca7cb0b96c2efe2b4f1e62b73d79e0d5b00498

ping @StabbyCutyou 